### PR TITLE
Remove catkin_pkg requirement since we are already using xml parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+import xml.etree.ElementTree as ET
 
-d = generate_distutils_setup(
-    packages=['odio_urdf'],
-    scripts=[],
-    package_dir={'odio_urdf':'odio_urdf'},
+pkg_info = ET.parse("package.xml")
+info = pkg_info.getroot()
+
+setup(
+    name="{}".format(info.find("name").text),
+    version="{}".format(info.find("version").text),
+    maintainer="{}".format(info.find("maintainer").text),
+    maintainer_email="{}".format(info.find("maintainer").attrib["email"]),
+    description="{}".format(info.find("description").text),
+    license="{}".format(info.find("license").text),
+    packages=["odio_urdf"],
+    package_dir={"odio_urdf": "odio_urdf"},
 )
-
-setup(**d)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 import xml.etree.ElementTree as ET
 
 pkg_info = ET.parse("package.xml")


### PR DESCRIPTION
There are two main modifications
. use xml parser instead of catkin_pkg 
. use setuptools as primary if it exists

Reason:
. make it non relative to catkin_pkg (ROS1)
. setuptools is more advanced